### PR TITLE
Add detailed READMEs for user-service, category-service, and eureka-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# personal-finance-app
-A personal finance management app built with a microservices architecture using Spring Boot, Kafka, WebFlux, PostgreSQL, MongoDB, and Docker.
+# Personal Finance App
+
+A personal finance management app built with a microservices architecture using **Spring Boot**, **Kafka**, **WebFlux**, **PostgreSQL**, **MongoDB**, and **Docker**.
+
+## 📦 Architecture Overview
+
+This project is composed of several microservices:
+
+| Service            | Description                           |
+| ------------------ | ------------------------------------- |
+| `user-service`     | Manages user authentication and data  |
+| `category-service` | Manages user-defined categories       |
+| *(...)*            | *(Other services will be added soon)* |
+
+>All services are registered with **Eureka** and communicate via **REST** and **Kafka events**.
+
+## 🚧 Status
+
+This project is currently in active development and evolving. Features, architecture, and services are being added and refined incrementally. Expect breaking changes and incomplete functionalities as development continues.  
+Contributions and feedback are welcome!
+
+## 🛠️ Tech Stack
+
+* **Spring Boot**
+* **Spring Cloud (Eureka, Feign)**
+* **Spring Security + JWT**
+* **Kafka (planned for event-driven communication)**
+* **PostgreSQL & MongoDB**
+* **Docker & Docker Compose (planned)**
+
+## 📁 Folder Structure
+
+```
+/
+├── user-service
+├── category-service
+├── ...
+└── README.md (you are here)
+```
+
+## 🔜 Roadmap
+
+* [x] Setup Eureka and service discovery
+* [x] Create user-service with JWT authentication
+* [x] Create category-service
+* [ ] Add transaction-service
+* [ ] Add analitics-service
+* [ ] Add Kafka event publishing/subscribing
+* [ ] Dockerize all services
+> This roadmap is a work in progress and may evolve over time.

--- a/category-service/README.md
+++ b/category-service/README.md
@@ -1,0 +1,101 @@
+# Category Service
+
+`category-service` is a Spring Boot microservice responsible for managing personal finance categories. It allows authenticated users to create, retrieve, update, and delete their own categories. It integrates with Eureka for service discovery and communicates with `user-service` through a Feign client to validate users.
+
+## Endpoints Overview
+
+| Method | Endpoint                 | Description                            |
+|--------|--------------------------|----------------------------------------|
+| POST   | /categories              | Create a new category for the user     |
+| GET    | /categories              | Get all categories of the user         |
+| GET    | /categories/{id}         | Get a specific category by ID          |
+| GET    | /categories/search       | Search categories by name              |
+| PUT    | /categories/{id}         | Update an existing category            |
+| DELETE | /categories/{id}         | Delete a category                      |
+
+>📌 **Note**: All endpoints are accessible via the `/category-service` base path.  
+🔐 All endpoints require a valid JWT in the `Authorization` header.
+
+## Security
+
+Although this service **does not use Spring Security**, it enforces **JWT-based authentication manually** by extracting and validating the token in service methods.  
+It uses a **Feign client** to contact the `user-service` and verify if a username exists and is valid.
+
+Custom security handling includes:
+- `FeignClientInterceptor` for forwarding JWT in Feign calls
+- Manual JWT parsing in the service layer
+- Token is expected in the `Authorization` header as: `Bearer <token>`
+
+
+## Database
+
+### Entities
+
+- **Category**: stores the name and ownership (username) of a category.
+
+### Data Initialization
+
+On startup, a list of base categories is automatically created for each new user if not already present:
+
+```java
+List<String> baseCategories = List.of("Health", "Entertainment", "Transport", "Food");
+````
+
+### Technology
+
+Uses PostgreSQL via Spring Data JPA.
+
+## Configuration Summary
+
+This service uses the following key configuration properties:
+
+* `spring.application.name`: `category-service`
+* `server.port`: port number where the service runs (e.g., `8082`)
+* `server.servlet.context-path`: base path for all endpoints (`/category-service`)
+* `spring.datasource.url`: PostgreSQL connection URL (uses environment variables)
+* `spring.jpa.*`: Hibernate and JPA settings
+* `eureka.client.service-url.defaultZone`: Eureka service registry URL
+* `security.constant`: custom JWT secret used for token validation (shared with `user-service`)
+
+> Full configuration can be found in [`application.yaml`](src/main/resources/application.yaml).
+
+All sensitive values (database credentials, JWT secret, etc.) are externalized using environment variables.
+
+## Feign Client Integration
+
+The service uses a Feign client to communicate with `user-service`:
+
+```java
+@FeignClient("user-service")
+public interface UserAuthClient {
+    @GetMapping("/user-service/users/{username}")
+    boolean isUsernameValid(@PathVariable String username);
+}
+```
+
+## Error Handling
+
+Includes custom exceptions for invalid categories, unauthorized access, or missing resources. Exceptions are handled globally and translated into meaningful HTTP responses.
+
+## Testing
+
+Includes basic unit and integration tests for:
+
+* Category creation and retrieval
+* User-category validation logic
+* Feign communication with `user-service`
+
+## Dependencies
+
+Main libraries used:
+
+* Spring Boot Starter Web
+* Spring Data JPA
+* Spring Cloud OpenFeign
+* PostgreSQL Driver
+* Eureka Client
+* Lombok
+* MapStruct
+* Jakarta Validation
+
+>📌 **Note**: This service is part of a larger microservice architecture. Docker and deployment instructions will be added in future iterations.

--- a/eureka-server/README.md
+++ b/eureka-server/README.md
@@ -1,0 +1,28 @@
+# Eureka Server
+
+## Description
+
+This microservice acts as a Eureka server, responsible for service registration and discovery within the microservice ecosystem. It provides a central point for microservices to register themselves and discover other services dynamically.
+
+## Basic Configuration
+
+* Application name: `eureka-server`
+* Runs on port: `8761`
+* Configured *not* to register itself or fetch the registry from other instances (`register-with-eureka=false`, `fetch-registry=false`).
+
+> Full configuration can be found in [`application.yaml`](src/main/resources/application.yaml).
+
+## Main Endpoints
+
+* Eureka Dashboard (UI): `http://localhost:8761/`
+  Allows you to view registered services and their statuses.
+
+## Technologies Used
+
+* Spring Boot
+* Spring Cloud Netflix Eureka Server
+
+## Additional Notes
+
+* This service does not register itself nor fetches the registry (`register-with-eureka: false`, `fetch-registry: false`).
+* It is essential to have this service running for other microservices to register properly.

--- a/user-service/README.md
+++ b/user-service/README.md
@@ -1,0 +1,72 @@
+# User Service
+
+`user-service` is a Spring Boot microservice responsible for user registration, authentication, and basic user data management. It provides JWT-based security and integrates with Eureka for service discovery.
+
+## Endpoints Overview
+
+| Method | Endpoint               | Description                        |
+|--------|------------------------|------------------------------------|
+| POST   | /auth/register         | Register a new user                |
+| POST   | /auth/login            | Authenticate user and get JWT      |
+| GET    | /users/all             | Get a list of all users            |
+| GET    | /users                 | Get basic info of authenticated user |
+| PUT    | /users                 | Update user password               |
+| GET    | /users/{username}      | Check if a username is available   |
+
+> **Note:** All endpoints are accessible via the `/user-service` base path.
+
+## Security
+
+- JWT-based authentication
+- Custom components:
+  - `JwtProvider`
+  - `JwtAuthenticationFilter`
+  - `JwtAuthenticationEntryPoint`
+  - `CustomUserDetailsService`
+- Configured in `SecurityConfig.java`
+
+## Database
+
+### Entities
+
+- **User**: stores basic user information (email, username, etc.).
+- **PasswordLog**: stores password history and failed login attempts for auditing.
+
+Uses **PostgreSQL** via Spring Data JPA.
+
+## Configuration Summary
+
+This service uses the following key configuration properties:
+
+- `spring.application.name`: `user-service`
+- `server.port`: `${SERVER_PORT}`
+- `spring.datasource.url`: PostgreSQL connection
+- `eureka.client.service-url.defaultZone`: Eureka registry URL
+- `security.constant`: Custom security constant used for JWT signing
+- `expiration.time.token`: JWT token expiration in milliseconds
+
+> Full configuration can be found in [`application.yaml`](src/main/resources/application.yaml).
+
+## Error Handling
+
+Includes a centralized global exception handler and custom exceptions for different error scenarios (e.g., invalid login, user not found, duplicate username/email).
+
+## Testing
+
+* Includes basic unit and integration tests.
+* Security-related components are partially tested.
+
+## Dependencies
+
+Main libraries used:
+
+* Spring Boot Starter Web
+* Spring Security
+* Spring Data JPA
+* PostgreSQL Driver
+* Eureka Client
+* JJWT (JSON Web Token)
+* MapStruct
+* Lombok
+
+> 📌 **Note**: This service is intended to be run as part of a microservice system. Docker and deployment instructions will be added in future iterations.


### PR DESCRIPTION
This PR adds comprehensive README files for the user-service, category-service, and eureka-server microservices.

Changes included:

- Created detailed README for user-service covering endpoints, security, configuration, and tech stack.
- Added README for category-service including endpoints, Feign client usage, base categories initialization, and configuration.
- Added README for eureka-server describing its role in service discovery and basic configuration.
- Updated main README with current project status, architecture overview, tech stack, and roadmap.

These documentation improvements aim to enhance project maintainability and ease onboarding for new contributors.