### PR TITLE
Add initial Swagger/OpenAPI documentation for user-service and category-service

### DIFF
--- a/category-service/pom.xml
+++ b/category-service/pom.xml
@@ -87,6 +87,11 @@
 			<version>${org.mapstruct.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/category-service/src/main/java/com/isaias/finance/category_service/config/OpenApiConfig.java
+++ b/category-service/src/main/java/com/isaias/finance/category_service/config/OpenApiConfig.java
@@ -1,0 +1,36 @@
+package com.isaias.finance.category_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Category Service API")
+                        .version("1.0.0")
+                        .description("API for managing user categories")
+                        .contact(new Contact()
+                                .name("Joel Isaías")
+                                .url("https://example.com")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/category-service/src/main/java/com/isaias/finance/category_service/controller/CategoryRestController.java
+++ b/category-service/src/main/java/com/isaias/finance/category_service/controller/CategoryRestController.java
@@ -1,7 +1,11 @@
 package com.isaias.finance.category_service.controller;
 
+import com.isaias.finance.category_service.config.OpenApiConfig;
 import com.isaias.finance.category_service.data.dto.*;
 import com.isaias.finance.category_service.domain.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +18,11 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/categories")
+@SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEME_NAME)
 public class CategoryRestController {
     private final CategoryService categoryService;
 
+    @Operation(summary = "Create a new category for the authenticated user")
     @PostMapping
     public ResponseEntity <CategoryCreationResponseDTO> createNewCategory (@RequestBody @Valid CategoryCreationRequestDTO category, HttpServletRequest request) {
         String jwt = request.getHeader("Authorization");
@@ -25,16 +31,27 @@ public class CategoryRestController {
                 HttpStatus.CREATED);
     }
 
+    @Operation(summary = "Get all categories for the authenticated user",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "List of categories retrieved successfully"),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized - JWT missing or invalid")
+            })
     @GetMapping()
     public UserCategoriesResponseDTO getAllUserCategories (@RequestHeader("Authorization") String jwt) {
         return categoryService.getAllUserCategories(jwt);
     }
 
+    @Operation(summary = "Get a specific category by ID for the authenticated user")
     @GetMapping("/{id}")
     public UserCategoryResponseDTO getCategoryById (@RequestHeader("Authorization") String jwtAuth, @PathVariable Long id) {
         return categoryService.getCategoryById (id, jwtAuth);
     }
 
+    @Operation(summary = "Search categories by name for the authenticated user",
+        responses = {
+                @ApiResponse(responseCode = "200", description = "Search completed"),
+                @ApiResponse(responseCode = "401", description = "Unauthorized - JWT missing or invalid")
+        })
     @GetMapping("/search")
     public List<UserCategoryResponseDTO> searchCategoriesByName (
             @RequestParam String name,
@@ -43,6 +60,7 @@ public class CategoryRestController {
         return categoryService.searchCategoriesByName(name, jwtAuth);
     }
 
+    @Operation(summary = "Update a category for the authenticated user")
     @PutMapping("/{id}")
     public UserCategoryResponseDTO updateCategory (
             @RequestBody @Valid CategoryUpdateDTO categoryUpdateDTO,
@@ -52,6 +70,7 @@ public class CategoryRestController {
         return categoryService.updateCategory(id, categoryUpdateDTO, jwtAuth);
     }
 
+    @Operation(summary = "Delete a category for the authenticated user")
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteCategory (
             @PathVariable Long id,

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version>
+			<version>2.8.8</version>
 		</dependency>
 
 		<dependency>

--- a/user-service/src/main/java/com/isaias/finance/user_service/config/OpenApiConfig.java
+++ b/user-service/src/main/java/com/isaias/finance/user_service/config/OpenApiConfig.java
@@ -1,0 +1,36 @@
+package com.isaias.finance.user_service.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("User Service API")
+                        .version("1.0.0")
+                        .description("API for managing users, authentication and registration")
+                        .contact(new Contact()
+                                .name("Joel Isaías")
+                                .url("https://example.com")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/user-service/src/main/java/com/isaias/finance/user_service/config/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/isaias/finance/user_service/config/security/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/auth/**",
-                                "/v3/api/docs",
+                                "/v3/api-docs",
                                 "/v3/api/docs.yaml",
                                 "/swagger-resources",
                                 "/swagger-ui/**"

--- a/user-service/src/main/java/com/isaias/finance/user_service/controller/UserRestController.java
+++ b/user-service/src/main/java/com/isaias/finance/user_service/controller/UserRestController.java
@@ -2,6 +2,12 @@ package com.isaias.finance.user_service.controller;
 
 import com.isaias.finance.user_service.data.dto.*;
 import com.isaias.finance.user_service.domain.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,37 +17,68 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+import static com.isaias.finance.user_service.config.OpenApiConfig.SECURITY_SCHEME_NAME;
+
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "User API", description = "Operations related to users authentication and management")
 public class UserRestController {
     private final UserService userService;
 
+    @Operation(summary = "Register a new user", responses = {
+            @ApiResponse(responseCode = "201", description = "User registered successfully",
+                    content = @Content(schema = @Schema(implementation = UserBasicDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input data")
+    })
     @PostMapping ("/auth/register")
     public ResponseEntity<UserBasicDTO> registerNewUser (@RequestBody @Valid UserRegistrationRequestDTO userRegistrationRequestDTO) {
         return new ResponseEntity <> (userService.registerNewUser(userRegistrationRequestDTO), HttpStatus.CREATED);
     }
 
+    @Operation(summary = "User login", responses = {
+            @ApiResponse(responseCode = "200", description = "Login successful",
+                    content = @Content(schema = @Schema(implementation = UserLoginResponseDTO.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - invalid credentials")
+    })
     @PostMapping ("/auth/login")
     public ResponseEntity<UserLoginResponseDTO> loginUser (@RequestBody @Valid UserLoginRequestDTO userLoginRequestDTO) {
         return new ResponseEntity <> (userService.loginUser(userLoginRequestDTO), HttpStatus.OK);
     }
 
+    @Operation(summary = "Get all users (public info)", responses = {
+            @ApiResponse(responseCode = "200", description = "List of all users",
+                    content = @Content(schema = @Schema(implementation = UserPublicDTO.class)))
+    })
+    @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     @GetMapping ("/users/all")
     public ResponseEntity<List<UserPublicDTO>> getAllUsers () {
         return new ResponseEntity <> (userService.getAllUsers(), HttpStatus.OK);
     }
 
+    @Operation(summary = "Get current logged in user info", responses = {
+            @ApiResponse(responseCode = "200", description = "User info",
+                    content = @Content(schema = @Schema(implementation = UserBasicDTO.class)))
+    })
+    @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     @GetMapping ("/users")
     public UserBasicDTO getUserInfo () {
         return userService.getUserInfo();
     }
 
+    @Operation(summary = "Update user password", responses = {
+            @ApiResponse(responseCode = "200", description = "Password updated successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid input data")
+    })
+    @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     @PutMapping ("/users")
     public ResponseEntity<?> updatePassword (@RequestBody @Valid PasswordUpdateDTO dto) {
         userService.updatePassword(dto);
         return ResponseEntity.ok(Map.of("message", "Password updated successfully."));
     }
 
+    @Operation(summary = "Check if username is valid", responses = {
+            @ApiResponse(responseCode = "200", description = "Returns true if username is valid, false otherwise")
+    })
     @GetMapping("/users/{username}")
     public boolean isUsernameValid (@PathVariable String username) {
         return userService.isUsernameValid(username);

--- a/user-service/src/main/resources/application.yaml
+++ b/user-service/src/main/resources/application.yaml
@@ -40,10 +40,3 @@ eureka:
       defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
   instance:
     preferIpAddress: true
-
-springdoc:
-  swagger-ui:
-    path: /swagger-ui
-  api-docs:
-    path: /v3/api-docs
-    enabled: true


### PR DESCRIPTION
This PR integrates Swagger/OpenAPI documentation setup for the `user-service` and `category-service` microservices.

### Changes included:

* Added `OpenApiConfig` to both `user-service` and `category-service` for consistent Swagger UI configuration (title, version, contact, JWT security scheme).
* Annotated controllers with `@Operation` and selectively used `@ApiResponse` to document key endpoints.
* Applied `@SecurityRequirement` at the controller level where appropriate (e.g., `CategoryRestController` where all endpoints require authentication).
* Ensured visibility of endpoints in Swagger UI and improved basic developer experience for API testing.

This is a foundational version of the documentation. In the future, more detailed annotations (descriptions, examples, error responses, etc.) can be added as the project evolves.